### PR TITLE
build: Setup jekyll dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/jekyll
+{
+	"name": "Developer's Journey",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/jekyll:2-bullseye",
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [4000],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "jekyll --version"
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"yzhang.markdown-all-in-one", 
+				"DavidAnson.vscode-markdownlint", 
+				"bierner.markdown-emoji",
+				"streetsidesoftware.code-spell-checker",
+				"bierner.markdown-preview-github-styles", 
+				"GitHub.vscode-pull-request-github"
+			]
+		}
+	},
+}

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ group :jekyll_plugins do
   gem 'jekyll-mermaid'
 end
 
-
+gem "liquid", "~> 4.0.4"
 gem "webrick", "~> 1.8"


### PR DESCRIPTION
Add [Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) to this repository to have a running environment of jekyll to blog everywhere and on every machine.